### PR TITLE
Fixed issue where `Coverage.parse` was attempting to call

### DIFF
--- a/lib/src/coveralls_entities.dart
+++ b/lib/src/coveralls_entities.dart
@@ -176,6 +176,9 @@ class Coverage {
     List<LineValue> values = [];
     var current = 1;
     for (int i = 0; i < numeration.length; i++) {
+      if (!numeration[i].contains('DA')) {
+        continue;
+      }
       var lineValue = LineValue.parse(numeration[i]);
       int distance = lineValue.lineNumber - values.length - 1;
       if (distance > 0)


### PR DESCRIPTION
`LineValue.parse` for strings which aren't DA line coverage entries.